### PR TITLE
http-keepalive

### DIFF
--- a/src/brynet/net/http/HttpParser.cpp
+++ b/src/brynet/net/http/HttpParser.cpp
@@ -172,8 +172,8 @@ size_t HTTPParser::tryParse(const char* buffer, size_t len)
     size_t nparsed = http_parser_execute(&mParser, &mSettings, buffer, len);
     http_parser_init(&mParser, mParserType);
 
-    mIsWebSocket = getValue("Upgrade") == "websocket";
-    mIsKeepAlive = !getValue("Keep-Alive").empty();
+    mIsWebSocket = hasEntry("Upgrade", "websocket");
+    mIsKeepAlive = !hasEntry("Connection", "close");
     mTmpHeadStr = nullptr;
     mTmpHeadLen = 0;
 
@@ -193,6 +193,12 @@ const std::string& HTTPParser::getQuery() const
 bool HTTPParser::isCompleted() const
 {
     return mISCompleted;
+}
+
+bool HTTPParser::hasEntry(const std::string& key, const std::string& value) const
+{
+    auto it = mHeadValues.find(key);
+    return it != mHeadValues.end() && value == it->second;
 }
 
 bool HTTPParser::hasKey(const std::string& key) const

--- a/src/brynet/net/http/HttpParser.h
+++ b/src/brynet/net/http/HttpParser.h
@@ -25,6 +25,7 @@ namespace brynet
             const std::string&                      getPath() const;
             const std::string&                      getQuery() const;
 
+            bool                                    hasEntry(const std::string& key, const std::string& value) const;
             bool                                    hasKey(const std::string& key) const;
             const std::string&                      getValue(const std::string& key) const;
             const std::string&                      getBody() const;


### PR DESCRIPTION
Keep alive when `Connection: close` header is not present.