### PR TITLE
optimize unregister pollerEvent in macos platform

### DIFF
--- a/include/brynet/net/TcpConnection.hpp
+++ b/include/brynet/net/TcpConnection.hpp
@@ -929,14 +929,14 @@ namespace brynet { namespace net {
             ev.data.ptr = (Channel*)(this);
             epoll_ctl(mEventLoop->getEpollHandle(), EPOLL_CTL_MOD, mSocket->getFD(), &ev);
 #elif defined BRYNET_PLATFORM_DARWIN
-            struct kevent ev[2];
-            memset(&ev, 0, sizeof(ev));
-            int n = 0;
-            EV_SET(&ev[n++], mSocket->getFD(), EVFILT_READ, EV_ENABLE, 0, 0, (Channel*)(this));
-            EV_SET(&ev[n++], mSocket->getFD(), EVFILT_WRITE, EV_ENABLE, 0, 0, (Channel*)(this));
+//             struct kevent ev[2];
+//             memset(&ev, 0, sizeof(ev));
+//             int n = 0;
+//             EV_SET(&ev[n++], mSocket->getFD(), EVFILT_READ, EV_ENABLE, 0, 0, (Channel*)(this));
+//             EV_SET(&ev[n++], mSocket->getFD(), EVFILT_WRITE, EV_ENABLE, 0, 0, (Channel*)(this));
 
-            struct timespec now = { 0, 0 };
-            kevent(mEventLoop->getKqueueHandle(), ev, n, NULL, 0, &now);
+//             struct timespec now = { 0, 0 };
+//             kevent(mEventLoop->getKqueueHandle(), ev, n, NULL, 0, &now);
 #endif
         }
         void                            unregisterPollerEvent()


### PR DESCRIPTION
 kqueue 会在 fd 被 closed 之后自动移除该 fd 上的所有事件，所以 kqueue 是不需要手动删除 fd 的，看 kqueue 的 manual：

> Calling close() on a file descriptor will remove any kevents that reference the descriptor.

https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2