### PR TITLE
fix: support ssl, no need to initial ssl lib when use.

### DIFF
--- a/examples/PingPongClient.cpp
+++ b/examples/PingPongClient.cpp
@@ -5,6 +5,7 @@
 #include <brynet/net/AsyncConnector.hpp>
 #include <brynet/net/wrapper/ConnectionBuilder.hpp>
 #include <brynet/base/AppStatus.hpp>
+//#define USE_SSL 0
 
 using namespace brynet;
 using namespace brynet::net;
@@ -37,10 +38,18 @@ int main(int argc, char **argv)
         std::cout << "connect failed" << std::endl;
     };
 
+#ifdef USE_SSL
+    SSLHelper::Ptr sslHelper = SSLHelper::Create();
+    sslHelper->initSSL();
+#endif // USE_SSL
+
     wrapper::ConnectionBuilder connectionBuilder;
     connectionBuilder.configureService(service)
         .configureConnector(connector)
         .configureConnectionOptions({
+#ifdef USE_SSL
+            brynet::net::AddSocketOption::WithClientSideSSL(),
+#endif // USE_SSL
             brynet::net::AddSocketOption::AddEnterCallback(enterCallback),
             brynet::net::AddSocketOption::WithMaxRecvBufferSize(1024 * 1024)
         });
@@ -48,6 +57,8 @@ int main(int argc, char **argv)
     const auto num = std::atoi(argv[4]);
     const auto ip = argv[1];
     const auto port = std::atoi(argv[2]);
+
+
     for (auto i = 0; i < num; i++)
     {
         try

--- a/examples/PingPongServer.cpp
+++ b/examples/PingPongServer.cpp
@@ -6,6 +6,7 @@
 #include <brynet/net/TcpService.hpp>
 #include <brynet/net/wrapper/ServiceBuilder.hpp>
 #include <brynet/base/AppStatus.hpp>
+//#define USE_SSL
 
 using namespace brynet;
 using namespace brynet::net;
@@ -40,7 +41,10 @@ int main(int argc, char **argv)
                 total_client_num--;
             });
     };
-
+#ifdef USE_SSL
+    SSLHelper::Ptr sslHelper = SSLHelper::Create();
+    sslHelper->initSSL("server.crt", "server.key");
+#endif // USE_SSL
     wrapper::ListenerBuilder listener;
     listener.configureService(service)
         .configureSocketOptions({
@@ -49,6 +53,9 @@ int main(int argc, char **argv)
             }
         })
         .configureConnectionOptions({
+#ifdef USE_SSL
+            brynet::net::AddSocketOption::WithServerSideSSL(sslHelper),
+#endif // USE_SSL
             brynet::net::AddSocketOption::WithMaxRecvBufferSize(1024 * 1024),
             brynet::net::AddSocketOption::AddEnterCallback(enterCallback)
         })

--- a/include/brynet/net/SSLHelper.hpp
+++ b/include/brynet/net/SSLHelper.hpp
@@ -83,8 +83,8 @@ namespace brynet { namespace net {
         using Ptr = std::shared_ptr<SSLHelper>;
 
 #ifdef BRYNET_USE_OPENSSL
-        bool        initSSL(const std::string& certificate,
-            const std::string& privatekey)
+        bool        initSSL(const std::string& certificate = "",
+            const std::string& privatekey = "")
         {
             std::call_once(initCryptoThreadSafeSupportOnceFlag, 
                 InitCryptoThreadSafeSupport);
@@ -93,6 +93,10 @@ namespace brynet { namespace net {
             {
                 return false;
             }
+            SSL_library_init();
+            OpenSSL_add_all_algorithms();
+            SSL_load_error_strings();
+
             if (certificate.empty() || privatekey.empty())
             {
                 return false;


### PR DESCRIPTION
作为独立的模块，外面使用时最好感知不到ssl相关api。(不知这样设计，是否是因为怕多个模块都引用ssl导致多次初始化？)