### PR TITLE
Fix build(VS2017 without /std:c++)

### DIFF
--- a/include/brynet/base/CPP_VERSION.hpp
+++ b/include/brynet/base/CPP_VERSION.hpp
@@ -11,6 +11,6 @@
 #endif
 
 #if (__cplusplus >= 201703L || \
-     (defined(_MSC_VER) && _MSC_VER >= 1910))
+     (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
 #define BRYNET_HAVE_LANG_CXX17 1
 #endif


### PR DESCRIPTION
In MSVC 2017, Brynet can't be compiled without `/std:c++17` or `/std:c++latest`

```
class any is only available with C++17 or later.
c:\dev\vcpkg-2020.07\installed\x64-windows\include\brynet\base\any.hpp(14): error C2039: 'any': is not a member of 'std'
```

Checking MSVC version is not enough for `std::any`. We should check _MSVC_LANG for this.
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
