### PR TITLE
Make it more Header-Only

### DIFF
--- a/include/brynet/base/Platform.hpp
+++ b/include/brynet/base/Platform.hpp
@@ -2,6 +2,7 @@
 
 #if defined _MSC_VER || defined __MINGW32__
 #define BRYNET_PLATFORM_WINDOWS
+#pragma comment(lib, "ws2_32")
 #elif defined __APPLE_CC__ || defined __APPLE__
 #define BRYNET_PLATFORM_DARWIN
 #else


### PR DESCRIPTION
Automatically link to ws2_32.lib on Windows Platform