### PR TITLE
Fix Keep-Alive Bug

### DIFF
--- a/include/brynet/net/http/HttpParser.hpp
+++ b/include/brynet/net/http/HttpParser.hpp
@@ -170,7 +170,8 @@ private:
         {
             mIsUpgrade = mParser.upgrade;
             mIsWebSocket = mIsUpgrade && hasEntry("Upgrade", "websocket");
-            mIsKeepAlive = hasEntry("Connection", "Keep-Alive");
+            auto &connHeader = getValue("Connection");
+            mIsKeepAlive = connHeader == "Keep-Alive" || connHeader == "keep-alive";
             mMethod = mParser.method;
             http_parser_init(&mParser, mParserType);
         }


### PR DESCRIPTION
测试发现keep-alive不生效，原因是Edge等浏览器发送的keep-alive是全小写的