### PR TITLE
In postDisConnect, use runFunctorAfterLoop for call `procCloseInLoop`…

### DIFF
--- a/include/brynet/net/TcpConnection.hpp
+++ b/include/brynet/net/TcpConnection.hpp
@@ -210,7 +210,10 @@ public:
     {
         auto sharedThis = shared_from_this();
         mEventLoop->runAsyncFunctor([sharedThis, this]() {
-            procCloseInLoop();
+            // call runFunctorAfterLoop, avoid user call postDisConnect in message callback, because after it brynet will use receive buffer.
+            mEventLoop->runFunctorAfterLoop([sharedThis, this]() {
+                procCloseInLoop();
+            });
         });
     }
 

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -139,6 +139,7 @@ TEST_CASE("http server are computed", "[http_server]")
                                     (void)session;
                                     REQUIRE(httpParser.getBody() == "<html>hello world </html>");
                                     counter.fetch_add(1);
+                                    session->postClose();
                                 });
                                 })
                             .asyncConnect();


### PR DESCRIPTION
…, avoid user call postDisConnect in message handler callback, because  brynet will use receive buffer after this callback.