### PR TITLE
Add `SSLHelper::InitThreadSafeSupport` for initialize the OpenSSL thread safe.

### DIFF
--- a/include/brynet/net/SSLHelper.hpp
+++ b/include/brynet/net/SSLHelper.hpp
@@ -82,11 +82,16 @@ public:
     using Ptr = std::shared_ptr<SSLHelper>;
 
 #ifdef BRYNET_USE_OPENSSL
-    bool initSSL(const std::string& certificate,
-                 const std::string& privatekey)
+    static void InitThreadSafeSupport()
     {
         std::call_once(initCryptoThreadSafeSupportOnceFlag,
                        InitCryptoThreadSafeSupport);
+    }    
+
+    bool initSSL(const std::string& certificate,
+                 const std::string& privatekey)
+    {
+        SSLHelper::InitThreadSafeSupport();
 
         if (mOpenSSLCTX != nullptr)
         {


### PR DESCRIPTION
We can call `SSLHelper::InitThreadSafeSupport` for initialize the lock callback for supoort thread safe of OpenSSL. This is useful for ssl client application.