### PR TITLE
Fix thread safety in WaitGroup and add static linkage to memsearch

### DIFF
--- a/include/brynet/base/WaitGroup.hpp
+++ b/include/brynet/base/WaitGroup.hpp
@@ -25,13 +25,18 @@ public:
 public:
     void add(int i = 1)
     {
+        std::unique_lock<std::mutex> l(mMutex);
         mCounter += i;
     }
 
     void done()
     {
+        std::unique_lock<std::mutex> l(mMutex);
         --mCounter;
-        mCond.notify_all();
+        if (mCounter <= 0)
+        {
+            mCond.notify_all();
+        }
     }
 
     void wait()
@@ -43,10 +48,10 @@ public:
     }
 
     template<class Rep, class Period>
-    void wait(const std::chrono::duration<Rep, Period>& timeout)
+    bool wait(const std::chrono::duration<Rep, Period>& timeout)
     {
         std::unique_lock<std::mutex> l(mMutex);
-        mCond.wait_for(l, timeout, [&] {
+        return mCond.wait_for(l, timeout, [&] {
             return mCounter <= 0;
         });
     }
@@ -61,7 +66,7 @@ private:
 
 private:
     std::mutex mMutex;
-    std::atomic<int> mCounter;
+    int mCounter;
     std::condition_variable mCond;
 };
 }}// namespace brynet::base

--- a/include/brynet/net/PromiseReceive.hpp
+++ b/include/brynet/net/PromiseReceive.hpp
@@ -5,7 +5,7 @@
 namespace brynet { namespace net {
 
 /* binary search in memory */
-void memsearch(const char* hay, size_t haysize, const char* needle, size_t needlesize, size_t& result, bool& isOK)
+static void memsearch(const char* hay, size_t haysize, const char* needle, size_t needlesize, size_t& result, bool& isOK)
 {
     size_t haypos, needlepos;
     haysize -= needlesize;


### PR DESCRIPTION
- Add mutex locking to WaitGroup::add() and done() for thread safety
- Only notify when counter reaches zero in done()
- Return bool from timed wait() to indicate success
- Change mCounter from atomic<int> to int (now protected by mutex)
- Add static to memsearch in PromiseReceive for internal linkage